### PR TITLE
Fix the name of Jupyter Notebook

### DIFF
--- a/ht19/preliminary.md
+++ b/ht19/preliminary.md
@@ -190,7 +190,7 @@ should see the current time printed with "big digits" ;)
 
 In the course, we will write Python code as standalone files. However,
 during the lecture, we will also use Jupyter
-notebooks. [Jupyter](//jupyter.org/) is a web-based tool which
+Notebook. [Jupyter](//jupyter.org/) is a web-based tool which
 allows us to evaluate our code line by line.  The Jupyter files are
 called
 [notebooks](//jupyter.readthedocs.io/en/latest/running.html) and


### PR DESCRIPTION
Just a miniature fix.

However, I additionally created issue https://github.com/NBISweden/workshop-python/issues/7 related to setup on Windows.